### PR TITLE
Use `encodeMessageFromSignable` to derive the message from the voucher

### DIFF
--- a/packages/extension/src/pages/services/Authz.js
+++ b/packages/extension/src/pages/services/Authz.js
@@ -44,8 +44,8 @@ export default function Authz() {
     const signable = data.body;
     const { hostname } = data.config.client;
     hostname && setHost(hostname);
-    if (signable.cadence) {
-      setTransactionCode(signable.cadence);
+    if (signable.voucher.cadence) {
+      setTransactionCode(signable.voucher.cadence);
     }
     setSignable(signable);
   }
@@ -98,7 +98,7 @@ export default function Authz() {
   async function sendAuthzToFCL() {
     initTransactionState();
     const signedMessage = await createSignature(
-      signable.message,
+      fcl.WalletUtils.encodeMessageFromSignable(signable, signable.addr),
       signable.addr,
       signable.keyId
     );


### PR DESCRIPTION
First of all, please include a license in this repository so that the licensing
status of contributions is clear.

As far as I understand, we can't trust that `signable.message` actually
corresponds to `signable.cadence`, so instead we should calculate the message
from `signable.voucher`, and display `signable.voucher.cadence` to the user to
ensure that they match.
